### PR TITLE
Do not trace child spans for same client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,9 @@ pub trait ExampleClientExt: private::Sealed {
 }
 
 impl ExampleClientExt for ExampleClient {
-    #[tracing::instrument(target = "ExampleClient::rotate", skip_all, fields(name), err)]
     async fn rotate<S: Into<Secret>>(&self, name: &str, secret: S) -> Result<Model> {
+        let _span = tracing::info_span!(target: "ExampleClient::rotate", "rotate", client = "ExampleClient").entered();
+
         let mut m = self.get_model(name).await?;
 
         tracing::event!(Level::DEBUG, "rotate secret");


### PR DESCRIPTION
Implements Azure SDK guideline https://azure.github.io/azure-sdk/general_implementation.html#general-tracing-suppress-client-spans-for-inner-methods
